### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
 
   def index
-    #@products = Product.all.order('created_at DESC')
+    @products = Product.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,7 +128,7 @@
     </div>
     <ul class='item-lists'>
 
-    <% unless @products != nil %>
+    <% if @products.size != 0 %>
       <% @products.each do |product| %>
         <li class='list'>
           <%= link_to products_path(product.id) do %>
@@ -157,22 +157,22 @@
           <% end %>
        </li>
       <% end %>     
-      <% else %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              商品を出品してね！
+            </h3>
+            <div class='item-price'>
+              <span>99999999円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
         <% end %>
       </li>
     <% end %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -128,37 +128,36 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+    <% unless @products != nil %>
+      <% @products.each do |product| %>
+        <li class='list'>
+          <%= link_to products_path(product.id) do %>
+            <div class='item-img-content'>
+              <%= image_tag product.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <%#div class='sold-out'>
+                <span>Sold Out!!</span>
+              </div>
+              <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= product.title %>
+              </h3>
+                <div class='item-price'>
+                  <span><%= product.price %>円<br><%= product.shipping_charge.name %></span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+            </div>
+          <% end %>
+       </li>
+      <% end %>     
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -176,8 +175,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -70,31 +70,31 @@ RSpec.describe Product, type: :model do
       it 'カテゴリーのプルダウンが"---"では登録できない' do
         @product.category_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include"Category must be other than 1"
+        expect(@product.errors.full_messages).to include 'Category must be other than 1'
       end
 
       it '商品の状態が"---"では登録できない' do
         @product.product_condition_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include"Product condition must be other than 1"
+        expect(@product.errors.full_messages).to include 'Product condition must be other than 1'
       end
 
       it '配送料の負担が"---"では登録できない' do
         @product.shipping_charge_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include"Shipping charge must be other than 1"
+        expect(@product.errors.full_messages).to include 'Shipping charge must be other than 1'
       end
 
       it '配送元の地域が"---"では登録できない' do
         @product.shipping_area_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include"Shipping area must be other than 1"
+        expect(@product.errors.full_messages).to include 'Shipping area must be other than 1'
       end
 
       it '発送までの日数が"---"では登録できない' do
         @product.shipping_ship_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include"Shipping ship must be other than 1"
+        expect(@product.errors.full_messages).to include 'Shipping ship must be other than 1'
       end
 
       it '販売価格が英字のみでは登録できない' do


### PR DESCRIPTION
#what
商品一覧機能の実装

#why
出品有無で表示を変えサンプル画像または商品一覧のトップ画面に表示させるため

検証データ
商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/ba783792cd10752e3e5405e2ed982c38
商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/9305a8184e74016a8b3ff6449623533f