### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,4 @@ gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
 gem "aws-sdk-s3", require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,6 +190,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.4.1)
       actionpack (= 6.0.4.1)
       activesupport (= 6.0.4.1)
@@ -325,6 +328,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima36029
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.i18n.default_locale = :ja
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,32 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: お名前（姓）
+        first_name: お名前（名）
+        kana_last_name: お名前カナ（姓）  
+        kana_first_name: お名前カナ（名） 
+        date_of_birth: 生年月日
+
+      product:
+        image: 商品画像
+        title: 商品名
+        product_description: 商品の説明
+        category_id: カテゴリー
+        product_condition_id: 商品の状態
+        shipping_charge_id: 配達費の負担
+        shipping_area_id: 発送元の地域
+        shipping_ship_id: 発送までの日数
+        price: 価格
+
+  attributes:
+    token: トークン
+    postal_code: 郵便番号
+    prefecture_id : 都道府県
+    city: 市区町村
+    house_number: 番地
+    building_name: 建物名
+    telephone_number: 電話番号
+    user_id: お名前
+    product_id: 商品

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -16,109 +16,109 @@ RSpec.describe Product, type: :model do
       it 'imageが空では登録されない' do
         @product.image = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include("Image can't be blank")
+        expect(@product.errors.full_messages).to include('商品画像を入力してください')
       end
 
       it '商品名が空では登録できない' do
         @product.title = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Title can't be blank")
+        expect(@product.errors.full_messages).to include('商品名を入力してください')
       end
 
       it '商品の説明が空では登録できない' do
         @product.product_description = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Product description can't be blank")
+        expect(@product.errors.full_messages).to include('商品の説明を入力してください')
       end
 
       it 'カテゴリーが空では登録できない' do
         @product.category_id = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include "Category can't be blank"
+        expect(@product.errors.full_messages).to include 'カテゴリーを入力してください'
       end
 
       it '商品の状態が空では登録できない' do
         @product.product_condition_id = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include "Product condition can't be blank"
+        expect(@product.errors.full_messages).to include '商品の状態を入力してください'
       end
 
       it '配送料の負担が空では登録できない' do
         @product.shipping_charge_id = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include "Shipping charge can't be blank"
+        expect(@product.errors.full_messages).to include '配達費の負担を入力してください'
       end
 
-      it '配送元の地域が空では登録できない' do
+      it '発送元の地域が空では登録できない' do
         @product.shipping_area_id = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include "Shipping area can't be blank"
+        expect(@product.errors.full_messages).to include '発送元の地域を入力してください'
       end
 
       it '発送までの日数が空では登録できない' do
         @product.shipping_ship_id = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include "Shipping ship can't be blank"
+        expect(@product.errors.full_messages).to include '発送までの日数を入力してください'
       end
 
       it '販売価格が空では登録できない' do
         @product.price = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include "Price can't be blank"
+        expect(@product.errors.full_messages).to include '価格を入力してください'
       end
 
       it 'カテゴリーのプルダウンが"---"では登録できない' do
         @product.category_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Category must be other than 1'
+        expect(@product.errors.full_messages).to include 'カテゴリーは1以外の値にしてください'
       end
 
       it '商品の状態が"---"では登録できない' do
         @product.product_condition_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Product condition must be other than 1'
+        expect(@product.errors.full_messages).to include '商品の状態は1以外の値にしてください'
       end
 
       it '配送料の負担が"---"では登録できない' do
         @product.shipping_charge_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Shipping charge must be other than 1'
+        expect(@product.errors.full_messages).to include '配達費の負担は1以外の値にしてください'
       end
 
-      it '配送元の地域が"---"では登録できない' do
+      it '発送元の地域が"---"では登録できない' do
         @product.shipping_area_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Shipping area must be other than 1'
+        expect(@product.errors.full_messages).to include '発送元の地域は1以外の値にしてください'
       end
 
       it '発送までの日数が"---"では登録できない' do
         @product.shipping_ship_id = '1'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Shipping ship must be other than 1'
+        expect(@product.errors.full_messages).to include '発送までの日数は1以外の値にしてください'
       end
 
       it '販売価格が英字のみでは登録できない' do
         @product.price = 'aaaaaa'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Price is not a number'
+        expect(@product.errors.full_messages).to include '価格は数値で入力してください'
       end
 
       it '販売価格に全角文字があると登録できない' do
         @product.price = 'あああ'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Price is not a number'
+        expect(@product.errors.full_messages).to include '価格は数値で入力してください'
       end
 
       it '販売価格が300以下であると登録できない' do
         @product.price = '299'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Price must be greater than 300'
+        expect(@product.errors.full_messages).to include '価格は299より大きい値にしてください'
       end
 
       it '販売価格が9999999以上であると登録できない' do
         @product.price = '10000000'
         @product.valid?
-        expect(@product.errors.full_messages).to include 'Price must be less than 9999999'
+        expect(@product.errors.full_messages).to include '価格は10000000より小さい値にしてください'
       end
     end
   end

--- a/spec/models/purchase_address_spec.rb
+++ b/spec/models/purchase_address_spec.rb
@@ -23,62 +23,62 @@ RSpec.describe PurchaseAddress, type: :model do
       it 'tokenが空では登録できないこと' do
         @purchase_address.token = nil
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include("Token can't be blank")
+        expect(@purchase_address.errors.full_messages).to include('トークンを入力してください')
       end
       it '郵便番号が空だと保存できないこと' do
         @purchase_address.postal_code = ''
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(postal_code: ["can't be blank", 'is invalid'])
+        expect(@purchase_address.errors.messages).to include(postal_code: %w[を入力してください は不正な値です])
       end
       it '郵便番号が半角のハイフンを含んだ正しい形式でないと保存できないこと' do
         @purchase_address.postal_code = '1112345'
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(postal_code: ['is invalid'])
+        expect(@purchase_address.errors.messages).to include(postal_code: ['は不正な値です'])
       end
       it '都道府県で1を選択すると保存できないこと' do
-        @purchase_address.prefecture_id = 1 
+        @purchase_address.prefecture_id = 1
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(prefecture_id: ["must be other than 1"])
+        expect(@purchase_address.errors.messages).to include(prefecture_id: ['は1以外の値にしてください'])
       end
       it '市区町村が空だと保存できないこと' do
         @purchase_address.city = ''
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(city: ["can't be blank"])
+        expect(@purchase_address.errors.messages).to include(city: ['を入力してください'])
       end
       it '番地が空だと保存できないこと' do
         @purchase_address.house_number = ''
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(house_number: ["can't be blank"])
+        expect(@purchase_address.errors.messages).to include(house_number: ['を入力してください'])
       end
       it '電話番号が空だと保存できないこと' do
         @purchase_address.telephone_number = ''
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(telephone_number: ["can't be blank", 'is invalid'])
+        expect(@purchase_address.errors.messages).to include(telephone_number: %w[を入力してください は不正な値です])
       end
       it '電話番号が半角数字9桁以下は保存できないこと' do
         @purchase_address.telephone_number = '123456789'
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(telephone_number: ['is invalid'])
+        expect(@purchase_address.errors.messages).to include(telephone_number: ['は不正な値です'])
       end
       it '電話番号が半角数12桁以上は保存できないこと' do
         @purchase_address.telephone_number = '123456789012'
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(telephone_number: ["is invalid"])
+        expect(@purchase_address.errors.messages).to include(telephone_number: ['は不正な値です'])
       end
       it '電話番号が半角数字以外が含まれている場合は保存できないこと' do
         @purchase_address.telephone_number = '1234５５５５５５'
         @purchase_address.valid?
-        expect(@purchase_address.errors.messages).to include(telephone_number: ['is invalid'])
+        expect(@purchase_address.errors.messages).to include(telephone_number: ['は不正な値です'])
       end
-      it 'productが紐付いていないと保存できないこと' do
+      it '商品が紐付いていないと保存できないこと' do
         @purchase_address.product_id = nil
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include("Product can't be blank")
+        expect(@purchase_address.errors.full_messages).to include('商品を入力してください')
       end
-      it 'userが紐付いていないと保存できないこと' do
+      it 'お名前が紐付いていないと保存できないこと' do
         @purchase_address.user_id = nil
         @purchase_address.valid?
-        expect(@purchase_address.errors.full_messages).to include("User can't be blank")
+        expect(@purchase_address.errors.full_messages).to include('お名前を入力してください')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe User, type: :model do
       it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include('ニックネームを入力してください')
       end
 
       it 'メールアドレスが空では登録できない' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include('Eメールを入力してください')
       end
 
       it 'emailに@が含まれていない場合登録できない' do
         @user.email = 'aaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Email is invalid'
+        expect(@user.errors.full_messages).to include('Eメールは不正な値です')
       end
 
       it '重複したemailが存在する場合登録できない' do
@@ -36,98 +36,98 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
       end
 
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank"
+        expect(@user.errors.full_messages).to include 'パスワードを入力してください'
       end
 
       it 'passwordが5文字以下であれば登録できない' do
         @user.password = '00000'
         @user.password_confirmation = '00000'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
+        expect(@user.errors.full_messages).to include 'パスワードは6文字以上で入力してください'
       end
 
       it 'passwordが存在してもpassword_confirmationが空では登録できない' do
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include 'パスワード（確認用）とパスワードの入力が一致しません'
       end
 
       it 'passwordが数字のみでは登録できない' do
         @user.password = '000000'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordが英字のみでは登録できない' do
         @user.password = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'passwordに全角文字があると登録できない' do
         @user.password = 'ａaaaa1'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Password is invalid'
+        expect(@user.errors.full_messages).to include 'パスワードは不正な値です'
       end
 
       it 'last_nameが空では登録できない' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前（姓）を入力してください'
       end
 
       it 'first_nameが空では登録できない' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前（名）を入力してください'
       end
 
       it 'last_nameが半角だと登録できない' do
         @user.last_name = 'Yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Last name is invalid'
+        expect(@user.errors.full_messages).to include 'お名前（姓）は不正な値です'
       end
 
       it 'first_nameが半角だと登録できない' do
         @user.first_name = 'Rintaro'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'First name is invalid'
+        expect(@user.errors.full_messages).to include 'お名前（名）は不正な値です'
       end
 
       it 'kana_last_nameが空では登録できない' do
         @user.kana_last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Kana last name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前カナ（姓）を入力してください'
       end
 
       it 'kana_first_nameが空では登録できない' do
         @user.kana_first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Kana first name can't be blank"
+        expect(@user.errors.full_messages).to include 'お名前カナ（名）を入力してください'
       end
 
       it 'kana_last_nameが半角だと登録できない' do
         @user.kana_last_name = 'Yamada'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Kana last name is invalid'
+        expect(@user.errors.full_messages).to include 'お名前カナ（姓）は不正な値です'
       end
 
       it 'kana_first_nameが半角だと登録できない' do
         @user.kana_first_name = 'Rikutaro'
         @user.valid?
-        expect(@user.errors.full_messages).to include 'Kana first name is invalid'
+        expect(@user.errors.full_messages).to include 'お名前カナ（名）は不正な値です'
       end
 
       it 'date_of_birthが空では登録できない' do
         @user.date_of_birth = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Date of birth can't be blank"
+        expect(@user.errors.full_messages).to include '生年月日を入力してください'
       end
     end
   end


### PR DESCRIPTION
＃What
エラーメッセージの日本語化

#Why
日本でのサービス展開を目指しているため、エラーメッセージを英語から日本語表記にしサービスを利用しやすくするため。